### PR TITLE
Reduce plugin configuration verbosity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.10'
+    ext.kotlin_version = '1.4.31'
 
     repositories {
         mavenCentral()
@@ -118,9 +118,7 @@ diffCoverageReport {
     classesDirs = files(subprojects.jacocoTestReport.classDirectories)
     srcDirs = files(subprojects.jacocoTestReport.sourceDirectories)
 
-    reports {
-        html = true
-    }
+    reportConfiguration.html = true
 
     violationRules {
         minBranches = 0.9

--- a/diff-coverage/src/funcTest/kotlin/com/form/plugins/DiffCoveragePluginTest.kt
+++ b/diff-coverage/src/funcTest/kotlin/com/form/plugins/DiffCoveragePluginTest.kt
@@ -238,10 +238,8 @@ class DiffCoveragePluginTest {
             diffCoverageReport {
                 diffSource.file = '$diffFilePath' 
                 violationRules {
-                    minBranches = 1.0
-                    minLines = 1.0
-                    minInstructions = 1.0 
-                    failOnViolation = false 
+                    failIfCoverageLessThan 1.0
+                    failOnViolation = false
                 }
             }
         """.trimIndent()
@@ -254,6 +252,9 @@ class DiffCoveragePluginTest {
 
         // assert
         result.assertDiffCoverageStatusEqualsTo(SUCCESS)
+        assertThat(result.output).contains(
+            "Fail on violations: false. Found violations: 3"
+        )
     }
 
     @Test

--- a/diff-coverage/src/main/kotlin/com/form/coverage/configuration/ChangesetCoverageConfiguration.kt
+++ b/diff-coverage/src/main/kotlin/com/form/coverage/configuration/ChangesetCoverageConfiguration.kt
@@ -78,6 +78,13 @@ open class ViolationRules(
     @Input var minInstructions: Double = 0.0,
     @Input var failOnViolation: Boolean = false
 ) {
+    fun failIfCoverageLessThan(minCoverage: Double) {
+        minLines = minCoverage
+        minBranches = minCoverage
+        minInstructions = minCoverage
+        failOnViolation = true
+    }
+
     override fun toString(): String {
         return "ViolationRules(" +
                 "minLines=$minLines, " +

--- a/diff-coverage/src/test/kotlin/com/form/coverage/configuration/ViolationRulesTest.kt
+++ b/diff-coverage/src/test/kotlin/com/form/coverage/configuration/ViolationRulesTest.kt
@@ -1,0 +1,21 @@
+package com.form.coverage.configuration
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+
+class ViolationRulesTest : StringSpec({
+
+    "failOnCoverageLessThan should set all coverage values to a single value and set failOnViolation=true" {
+        val expectedCoverage = 0.9
+        val violationRules = ViolationRules().apply {
+            failIfCoverageLessThan(expectedCoverage)
+        }
+
+        violationRules shouldBeEqualToComparingFields ViolationRules(
+            expectedCoverage,
+            expectedCoverage,
+            expectedCoverage,
+            true
+        )
+    }
+})


### PR DESCRIPTION
added a function to simplify violations configuration
```
diffCoverageReport {
    diffSource {
        ...
    }
    
    violationRules.failIfCoverageLessThan 0.9
}
```
The function is equivavalent to 
```
violationRules {
    minBranches = 0.9
    minLines = 0.9
    minInstructions = 0.9
    failOnViolation = true
}
```