### PR TITLE
Support for Java 18.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ subprojects {
     }
 
     jacoco {
-        toolVersion = "0.8.7"
+        toolVersion = "0.8.8"
     }
 
     jacocoTestReport {

--- a/jacoco-filtering-extension/build.gradle
+++ b/jacoco-filtering-extension/build.gradle
@@ -1,7 +1,7 @@
 group 'com.form.coverage'
 
 ext {
-    jacoco_version = '0.8.7'
+    jacoco_version = '0.8.8'
 }
 
 publishing {


### PR DESCRIPTION
The current version (0.9.3) does not support Java 18 due to an older version of Jacoco.