### PR TITLE
There are two reasons for the error in the total instruction number:

### DIFF
--- a/jacoco-filtering-extension/src/main/kotlin/com/form/coverage/diff/git/JgitDiff.kt
+++ b/jacoco-filtering-extension/src/main/kotlin/com/form/coverage/diff/git/JgitDiff.kt
@@ -3,6 +3,7 @@ package com.form.coverage.diff.git
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.diff.DiffEntry
 import org.eclipse.jgit.diff.DiffFormatter
+import org.eclipse.jgit.diff.RawTextComparator
 import org.eclipse.jgit.lib.ConfigConstants
 import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.ObjectId
@@ -39,6 +40,8 @@ class JgitDiff(workingDir: File) {
         Git(repository).use { git ->
             DiffFormatter(diffContent).apply {
                 initialize()
+
+                setDiffComparator(RawTextComparator.WS_IGNORE_ALL)
 
                 obtainDiffEntries(git, revision).forEach {
                     format(it)

--- a/jacoco-filtering-extension/src/main/kotlin/com/form/coverage/filters/ModifiedLinesFilter.kt
+++ b/jacoco-filtering-extension/src/main/kotlin/com/form/coverage/filters/ModifiedLinesFilter.kt
@@ -42,6 +42,10 @@ class ModifiedLinesFilter(private val codeUpdateInfo: CodeUpdateInfo) : IFilter 
                     log.debug("\tlines: $it")
                 }
         }
+
+        if (groupedModifiedLines[true].isNullOrEmpty()) {
+            output.ignore(methodNode.instructions.first, methodNode.instructions.last)
+        }
     }
 
     private fun collectLineNodes(instructionNodes: InsnList): Sequence<LineNode> {


### PR DESCRIPTION
- The current method of ignoring instructions based on the number of code changes has issues. The current logic only ignores bytecode in LINENUMBER node blocks, leading to some unforeseen situations in Kotlin. I have submitted a pull request that ignores all Linenumber bytecode within a method that is not part of the code changes. This adjustment yields the desired result in the graph.

Before
<img width="499" alt="Screenshot 2024-01-17 110128" src="https://github.com/form-com/diff-coverage-gradle/assets/6906187/281301ff-9efb-4227-be7c-f4dc8c1cd7d5">

After
<img width="422" alt="Screenshot 2024-01-17 110307" src="https://github.com/form-com/diff-coverage-gradle/assets/6906187/81064331-91f0-4bb4-8b1e-a435ac3e6994">


- The algorithm for determining the result line numbers of code changes also contributes to miscalculating the total line number. Applying the 'ignore space' differential strategy could prove beneficial in this scenario.

For example:

'git diff' default output is,

```
--- a/app/src/main/java/org/angmarch/jacococompose/ComposeComponent.kt +++ b/app/src/main/java/org/angmarch/jacococompose/ComposeComponent.kt @@ -16,4 +16,8 @@ fun ComposeComponent(text: String) {
     Surface {
         Text(text = text)
     }
+} <- this would cause wrong instruction being retained in pull request coverage report. 
+
+fun catchMeIfYouCan() {
+    println("I'm a testable function")
 }
```
A more favorable outcome could be achieved by issuing the command 'git diff -b' to ignore space changes.

```
--- a/app/src/main/java/org/angmarch/jacococompose/ComposeComponent.kt +++ b/app/src/main/java/org/angmarch/jacococompose/ComposeComponent.kt @@ -17,3 +17,7 @@ fun ComposeComponent(text: String) {
         Text(text = text)
     }
 }
+
+fun catchMeIfYouCan() {
+    println("I'm a testable function")
+}
```